### PR TITLE
fix: package.json & .snyk to reduce vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,19 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.1
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  'npm:backbone:20110701':
+    - tilestream > bones > backbone:
+        patched: '2017-10-11T13:57:57.208Z'
+  'npm:minimatch:20160620':
+    - tilestream > mbtiles > sqlite3 > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2017-10-11T13:57:57.208Z'
+  'npm:semver:20150403':
+    - tilestream > mbtiles > sqlite3 > node-pre-gyp > semver:
+        patched: '2017-10-11T13:57:57.208Z'
+  'npm:tar:20151103':
+    - tilestream > mbtiles > sqlite3 > node-pre-gyp > tar:
+        patched: '2017-10-11T13:57:57.208Z'
+    - tilestream > mbtiles > sqlite3 > node-pre-gyp > tar-pack > tar:
+        patched: '2017-10-11T13:57:57.208Z'

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
   "version": "0.0.1",
   "author": "c4hrva",
   "dependencies": {
-    "tilestream": "1.1.0"
+    "tilestream": "1.1.0",
+    "snyk": "^1.42.6"
   },
-  "engines":{ 
-    "node":"0.10.26",
+  "engines": {
+    "node": "0.10.26",
     "npm": "1.4.3"
-  }
+  },
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }


### PR DESCRIPTION
The following vulnerabilities are fixed with a Snyk patch:
- https://snyk.io/vuln/npm:backbone:20110701
- https://snyk.io/vuln/npm:minimatch:20160620
- https://snyk.io/vuln/npm:semver:20150403
- https://snyk.io/vuln/npm:tar:20151103

Latest report for code4hr/norfolkart-tiles:
https://snyk.io/test/github/code4hr/norfolkart-tiles